### PR TITLE
Feature/store board as hash

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -24,9 +24,7 @@ class Board
   end
 
   def format_board
-    @grid.unshift(@header)
-    formatted_board = @grid.map { |row| row.join }
-    @grid.shift
-    formatted_board
+    formatted_board = @grid.values.transpose
+    formatted_board.unshift(@grid.keys).map {|row| row.join}
   end
 end

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -5,14 +5,18 @@ class Board
               :grid
 
   def initialize
-    @header = ["A", "B", "C", "D", "E", "F", "G"]
     @rows = 6
     @columns = 7
     @grid = make_grid
   end
 
   def make_grid
-    Array.new(@rows, Array.new(@columns, "."))
+    header = ["A", "B", "C", "D", "E", "F", "G"]
+    grid = Hash.new {|grid, letter| grid[letter] = [".", ".", ".", ".", ".", "."]}
+    header.map do |letter|
+      grid[letter]
+    end
+    grid
   end
 
   def print_board

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -19,10 +19,6 @@ describe Board do
       expect(@board.grid.values.sample).to eq([".", ".", ".", ".", ".", "."])
     end
 
-    # xit 'has a header' do
-    #   expect(@board.header).to eq(["A", "B", "C", "D", "E", "F", "G"])
-    # end
-
     xit 'has a row count of 6 by default' do
       expect(@board.rows).to eq(6)
     end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -5,43 +5,45 @@ describe Board do
     @board = Board.new
   end
   describe '#initialize' do
-    it 'exists' do
+    xit 'exists' do
       expect(@board).to be_a Board
     end
 
     it 'has a grid' do
-      expect(@board.grid).to be_a Array
+      expect(@board.grid).to be_a Hash
+      expect(@board.grid.keys).to eq(["A", "B", "C", "D", "E", "F", "G"])
+      expect(@board.grid.values.count).to eq(7)
+      expect(@board.grid.values.sample).to eq([".", ".", ".", ".", ".", "."])
     end
 
-
-    it 'board is blank by default' do
+    xit 'board is blank by default' do
       expect(@board.grid.all? do |array|
         array.all?{|element| element == "."}
       end).to be true
     end
 
-    it 'has a header' do
-      expect(@board.header).to eq(["A", "B", "C", "D", "E", "F", "G"])
-    end
+    # xit 'has a header' do
+    #   expect(@board.header).to eq(["A", "B", "C", "D", "E", "F", "G"])
+    # end
 
-    it 'has a row count of 6 by default' do
+    xit 'has a row count of 6 by default' do
       expect(@board.rows).to eq(6)
     end
 
-    it 'has a column count of 7 by default' do
+    xit 'has a column count of 7 by default' do
       expect(@board.columns).to eq(7)
     end
   end
 
   describe '#make_grid' do
-    it 'has 6 subarrays of 7 elements each by default' do
+    xit 'has 6 subarrays of 7 elements each by default' do
       expect(@board.grid.count).to eq(@board.rows)
       expect(@board.grid.sample.count).to eq(@board.columns)
     end
   end
 
   describe '#format_board' do
-    it 'can format subarrays to strings' do
+    xit 'can format subarrays to strings' do
       expect(@board.format_board).to be_a Array
       expect(@board.format_board.count).to eq(@board.rows + 1)
       expect(@board.format_board.sample[0]).to be_a String

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -36,11 +36,11 @@ describe Board do
   end
 
   describe '#format_board' do
-    xit 'can format subarrays to strings' do
+    it 'can format subarrays to strings' do
       expect(@board.format_board).to be_a Array
       expect(@board.format_board.count).to eq(@board.rows + 1)
       expect(@board.format_board.sample[0]).to be_a String
-      expect(@board.format_board[0]).to eq(@board.header.join)
+      expect(@board.format_board[0]).to eq(@grid.keys.join)
       expect(@board.format_board.sample.length).to eq(@board.columns)
     end
   end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -19,19 +19,19 @@ describe Board do
       expect(@board.grid.values.sample).to eq([".", ".", ".", ".", ".", "."])
     end
 
-    xit 'has a row count of 6 by default' do
+    it 'has a row count of 6 by default' do
       expect(@board.rows).to eq(6)
     end
 
-    xit 'has a column count of 7 by default' do
+    it 'has a column count of 7 by default' do
       expect(@board.columns).to eq(7)
     end
   end
 
   describe '#make_grid' do
-    xit 'has 6 subarrays of 7 elements each by default' do
-      expect(@board.grid.count).to eq(@board.rows)
-      expect(@board.grid.sample.count).to eq(@board.columns)
+    it 'has 6 subarrays of 7 elements each by default' do
+      expect(@board.grid.values.sample.count).to eq(@board.rows)
+      expect(@board.grid.keys.count).to eq(@board.columns)
     end
   end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -40,7 +40,7 @@ describe Board do
       expect(@board.format_board).to be_a Array
       expect(@board.format_board.count).to eq(@board.rows + 1)
       expect(@board.format_board.sample[0]).to be_a String
-      expect(@board.format_board[0]).to eq(@grid.keys.join)
+      expect(@board.format_board[0]).to eq(@board.grid.keys.join)
       expect(@board.format_board.sample.length).to eq(@board.columns)
     end
   end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -5,7 +5,7 @@ describe Board do
     @board = Board.new
   end
   describe '#initialize' do
-    xit 'exists' do
+    it 'exists' do
       expect(@board).to be_a Board
     end
 
@@ -13,13 +13,10 @@ describe Board do
       expect(@board.grid).to be_a Hash
       expect(@board.grid.keys).to eq(["A", "B", "C", "D", "E", "F", "G"])
       expect(@board.grid.values.count).to eq(7)
-      expect(@board.grid.values.sample).to eq([".", ".", ".", ".", ".", "."])
     end
 
-    xit 'board is blank by default' do
-      expect(@board.grid.all? do |array|
-        array.all?{|element| element == "."}
-      end).to be true
+    it 'board is blank by default' do
+      expect(@board.grid.values.sample).to eq([".", ".", ".", ".", ".", "."])
     end
 
     # xit 'has a header' do


### PR DESCRIPTION
This PR updates the grid attribute in the Board class to be stored as a hash, instead of an array. Tests have been updated to reflect the new data structure.

This code was written as a pair.