### PR TITLE
refactor: edit test for get human selection method with valid input

### DIFF
--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -49,12 +49,13 @@ describe Game do
   end
 
   describe '#get_human_selection' do
-      let(:valid_input) {StringIO.new('B')}
-
     it 'returns a valid column selection when input is valid' do
+      valid_input = StringIO.new('B')
       $stdin = valid_input
+
       human_selection = @game.get_human_selection
       expect(human_selection).to be_a String
+      expect(human_selection).to eq('B')
       expect(human_selection.length).to eq(1)
       expect(@valid_columns).to include(human_selection)
       $stdin = STDIN


### PR DESCRIPTION
This PR simplifies the test for the get human selection method in the Game class.  This test confirms that when a user inputs a valid response to the terminal, the method evaluates and returns the selection. 

In this test:
- The first line creates a valid input variable for the purpose of this test, and sets it to equal the StringIO object 'B'. 
- The second line tells Ruby to look for this variable's value instead of the user's input when running the method in the test.
- The third line calls the method as part of the test setup.
- The remaining lines are the test expectations.

Referenced [this article](https://www.rubyguides.com/2017/05/stringio-objects/) to learn about using Ruby's StringIO class to replace the standard input object ($stdin). See heading 'Replacing Standard Input & Output' for more.